### PR TITLE
Reverse the dependency between dns-client-lwt and happy-eyeballs-lwt (dns-client-mirage and happy-eyeballs-mirage)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,4 +18,5 @@ freebsd_task:
     - opam source dns-client
 
   build_script:
+    - opam install -y --deps-only -t dns dns-client dns-client-lwt dns-client-mirage
     - opam exec -- dune build -p happy-eyeballs,happy-eyeballs-lwt,happy-eyeballs-mirage,dns,dns-client,dns-client-lwt,dns-client-mirage

--- a/happy-eyeballs-lwt.opam
+++ b/happy-eyeballs-lwt.opam
@@ -13,7 +13,7 @@ depends: [
   "happy-eyeballs" {=version}
   "cmdliner" {>= "1.1.0"}
   "duration"
-  "dns-client-lwt" {>= "7.0.0"}
+  "dns" {>= "7.0.0"}
   "domain-name"
   "ipaddr"
   "fmt"

--- a/happy-eyeballs-mirage.opam
+++ b/happy-eyeballs-mirage.opam
@@ -12,8 +12,6 @@ depends: [
   "dune" {>= "2.0.0"}
   "happy-eyeballs" {=version}
   "duration"
-  "dns-client" {>= "7.0.0"}
-  "dns-client-mirage" {>= "7.0.0"}
   "domain-name"
   "ipaddr"
   "fmt"

--- a/lwt/dune
+++ b/lwt/dune
@@ -1,4 +1,4 @@
 (library
  (name happy_eyeballs_lwt)
  (public_name happy-eyeballs-lwt)
- (libraries logs dns-client-lwt lwt lwt.unix happy-eyeballs))
+ (libraries logs dns lwt mtime.clock.os ipaddr.unix lwt.unix happy-eyeballs))

--- a/lwt/dune
+++ b/lwt/dune
@@ -1,4 +1,4 @@
 (library
  (name happy_eyeballs_lwt)
  (public_name happy-eyeballs-lwt)
- (libraries logs dns lwt mtime.clock.os ipaddr.unix lwt.unix happy-eyeballs))
+ (libraries logs lwt mtime.clock.os ipaddr.unix lwt.unix happy-eyeballs))

--- a/lwt/happy_eyeballs_lwt.ml
+++ b/lwt/happy_eyeballs_lwt.ml
@@ -24,7 +24,7 @@ type t = {
 
 let _cnt = ref 0
 
-let inject getaddrinfo t =
+let inject t getaddrinfo =
   incr _cnt;
   t.getaddrinfo <- getaddrinfo;
   if !_cnt > 1 then

--- a/lwt/happy_eyeballs_lwt.ml
+++ b/lwt/happy_eyeballs_lwt.ml
@@ -25,8 +25,8 @@ type t = {
   mutable dns : getaddrinfo ;
 }
 
-let inject ~getaddrinfo t =
-  t.getaddrinfo <- getaddrinfo
+let inject getaddrinfo t =
+  t.dns <- getaddrinfo
 
 let safe_close fd =
   if Lwt_unix.state fd = Lwt_unix.Closed then

--- a/lwt/happy_eyeballs_lwt.mli
+++ b/lwt/happy_eyeballs_lwt.mli
@@ -1,11 +1,17 @@
 (** The type of the abstract state of happy eyeballs. *)
 type t
 
-val create : ?happy_eyeballs:Happy_eyeballs.t -> ?dns:Dns_client_lwt.t ->
+type getaddrinfo = {
+  getaddrinfo : 'response 'a.
+    'response Dns.Rr_map.key -> 'a Domain_name.t -> ('response, [ `Msg of string ]) result Lwt.t
+} [@@unboxed]
+
+val create : ?happy_eyeballs:Happy_eyeballs.t ->
+  ?getaddrinfo:getaddrinfo ->
   ?timer_interval:int64 -> unit -> t
-(** [create ~happy_eyeballs ~dns ~timer_interval ()] creates an initial state
-    of happy eyeballs with the specified timeouts in nanoseconds - the default
-    for [timer_interval] is [Duration.of_ms 10]. *)
+(** [create ~happy_eyeballs ~getaddrinfo ~timer_interval ()] creates an initial
+    state of happy eyeballs with the specified timeouts in nanoseconds - the
+    default for [timer_interval] is [Duration.of_ms 10]. *)
 
 val connect_host : t -> [`host] Domain_name.t -> int list ->
   ((Ipaddr.t * int) * Lwt_unix.file_descr, [ `Msg of string ]) result Lwt.t
@@ -26,3 +32,5 @@ val connect : t -> string -> int list ->
     may be a host name, or an IP address.
 
     @raise Failure if [ports] is the empty list. *)
+
+val inject : getaddrinfo:getaddrinfo -> t -> unit

--- a/lwt/happy_eyeballs_lwt.mli
+++ b/lwt/happy_eyeballs_lwt.mli
@@ -31,22 +31,22 @@ val connect : t -> string -> int list ->
     @raise Failure if [ports] is the empty list. *)
 
 val inject : getaddrinfo -> t -> unit
-(** [inject getaddrinfo t] injects a domain-name resolver into the given
-    happy-eyeballs instance. By default, the happy-eyeballs instance is not
-    able to resolve domain-name. However, if the user has an implementation
-    of [getaddrinfo] which is able to resolve domain-name, the user can
-    inject it. By this way, the function {!val:connect_host} will works.
+(** [inject getaddrinfo t] injects a {i new} domain-name resolver into the given
+    happy-eyeballs instance. By default, the happy-eyeballs instance use
+    {!val:Unix.getaddrinfo} to be able to resolve domain-name. However, the user
+    can choose to use its own implementation of a DNS resolver (like
+    [ocaml-dns]).
 
-    So, the usual {i ceremony} for using happy-eyeballs is to create a
-    happy-eyeballs instance, obtain an instance that can resolve domain names
-    (such as [ocaml-dns]) and inject the latter's implementation into our first
-    happy-eyeballs instance:
+    So, the {i ceremony} for using happy-eyeballs with your own DNS resolver is
+    to create a happy-eyeballs instance, obtain an instance that can resolve
+    domain names (such as [ocaml-dns]) and inject the latter's implementation
+    into our first happy-eyeballs instance:
 
     {[
       let _ =
         let happy_eyeballs = Happy_eyeballs_lwt.create () in
-        let dns = Dns_lwt.create () in
-        Happy_eyeballs_lwt.inject (Dns_lwt.getaddrinfo dns) happy_eyeballs;
+        let dns = Dns_client_lwt.create () in
+        Happy_eyeballs_lwt.inject (Dns_client_lwt.getaddrinfo dns) happy_eyeballs;
         Happy_eyeballs_lwt.connect happy_eyeballs "robur.coop" [ 443 ]
         >>= function
         | Ok (_, fd) -> ...

--- a/lwt/happy_eyeballs_lwt.mli
+++ b/lwt/happy_eyeballs_lwt.mli
@@ -44,9 +44,8 @@ val inject : t -> getaddrinfo -> unit
 
     {[
       let _ =
-        let happy_eyeballs = Happy_eyeballs_lwt.create () in
         let dns = Dns_client_lwt.create () in
-        Happy_eyeballs_lwt.inject happy_eyeballs (Dns_client_lwt.getaddrinfo dns);
+        let happy_eyeballs = Dns_client_lwt.create_happy_eyeballs dns in
         Happy_eyeballs_lwt.connect happy_eyeballs "robur.coop" [ 443 ]
         >>= function
         | Ok (_, fd) -> ...

--- a/lwt/happy_eyeballs_lwt.mli
+++ b/lwt/happy_eyeballs_lwt.mli
@@ -30,11 +30,11 @@ val connect : t -> string -> int list ->
 
     @raise Failure if [ports] is the empty list. *)
 
-val inject : getaddrinfo -> t -> unit
-(** [inject getaddrinfo t] injects a {i new} domain-name resolver into the given
+val inject : t -> getaddrinfo -> unit
+(** [inject t getaddrinfo] injects a {i new} domain-name resolver into the given
     happy-eyeballs instance. By default, the happy-eyeballs instance use
-    {!val:Unix.getaddrinfo} to be able to resolve domain-name. However, the user
-    can choose to use its own implementation of a DNS resolver (like
+    {!val:Lwt_unix.getaddrinfo} to be able to resolve domain-name. However, the
+    user can choose to use its own implementation of a DNS resolver (like
     [ocaml-dns]).
 
     So, the {i ceremony} for using happy-eyeballs with your own DNS resolver is
@@ -46,7 +46,7 @@ val inject : getaddrinfo -> t -> unit
       let _ =
         let happy_eyeballs = Happy_eyeballs_lwt.create () in
         let dns = Dns_client_lwt.create () in
-        Happy_eyeballs_lwt.inject (Dns_client_lwt.getaddrinfo dns) happy_eyeballs;
+        Happy_eyeballs_lwt.inject happy_eyeballs (Dns_client_lwt.getaddrinfo dns);
         Happy_eyeballs_lwt.connect happy_eyeballs "robur.coop" [ 443 ]
         >>= function
         | Ok (_, fd) -> ...

--- a/lwt/happy_eyeballs_lwt.mli
+++ b/lwt/happy_eyeballs_lwt.mli
@@ -33,4 +33,9 @@ val connect : t -> string -> int list ->
 
     @raise Failure if [ports] is the empty list. *)
 
-val inject : getaddrinfo:getaddrinfo -> t -> unit
+val inject : getaddrinfo -> t -> unit
+(** [inject getaddrinfo t] injects a domain-name resolver into the given
+    happy-eyeballs instance. By default, the happy-eyeballs instance is not
+    able to resolve domain-name. However, if the user has an implementation
+    of [getaddrinfo] which is able to resolve domain-name, the user can
+    inject it. By this way, the function {!val:connect_host} will works. *)

--- a/mirage/dune
+++ b/mirage/dune
@@ -1,4 +1,4 @@
 (library
  (name happy_eyeballs_mirage)
  (public_name happy-eyeballs-mirage)
- (libraries logs duration dns-client dns-client-mirage domain-name ipaddr lwt fmt tcpip happy-eyeballs mirage-clock mirage-time))
+ (libraries logs duration domain-name ipaddr lwt fmt tcpip happy-eyeballs mirage-clock mirage-time))


### PR DESCRIPTION
As discussed with @hannesm and @reynir, this patch is a possible way to unlock the cycle between `happy-eyeballs`, `happy-eyeballs-lwt`, `dns` and `dns-client-lwt`. The idea is to use an internal function to resolve domain-name instead of `Dns_client_lwt`. The user is able to create a `Dns_client_lwt` from an `Happy_eyeballs_lwt` instance (and, by this way, we delete a duplicated code to handle connections). Then, the user is able to "inject" its `getaddrinfo` from its new `Dns_client_lwt` instance into its `Happy_eyeballs_lwt` instance. By this way, `Happy_eyeballs_lwt` is able to handle connections **and** domain-name resolution without a duplication of the code.